### PR TITLE
custom png_from_web component

### DIFF
--- a/custom_components.py
+++ b/custom_components.py
@@ -1,0 +1,27 @@
+import base64
+import urllib.request
+
+from pinout import templates
+from pinout.core import SvgShape
+
+class PNG_from_web(SvgShape):
+
+    def __init__(self, path, embed=False, **kwargs):
+        super().__init__(**kwargs)
+        self.path = path
+        self.svg_data = None
+        self.embed = embed
+
+    def render(self):
+        """Linking or embed a PNG formatted image from a web url."""
+        
+        tplt = templates.get("image.svg")
+        if self.embed:
+
+            with urllib.request.urlopen(self.path) as f:
+                imgdata = f.read()
+
+            encoded_img = base64.b64encode(imgdata)
+            self.path = f"data:image/png;base64,{encoded_img.decode('utf-8')}"
+
+        return tplt.render(image=self)

--- a/pinout_ulx3s.py
+++ b/pinout_ulx3s.py
@@ -6,13 +6,14 @@
 #
 ###########################################
 
-from pinout.core import Group, Image
+from pinout.core import Group
 from pinout.components.layout import Diagram, Panel
 from pinout.components.pinlabel import PinLabelGroup, PinLabel
 from pinout.components.text import TextBlock
 from pinout.components import leaderline as lline
 from pinout.components.legend import Legend
 
+from custom_components import PNG_from_web
 
 # Import data for the diagram
 import data
@@ -54,7 +55,10 @@ panel_info = content.add(
 graphic = panel_main.add(Group(1, 1))
 
 # Add and embed an image
-graphic.add(Image("./ulx3s.png", width=1372, height=742, embed=True))
+graphic.add(PNG_from_web("https://raw.githubusercontent.com/ulx3s/ulx3s-pinout/main/ulx3s.png", width=1372, height=742, embed=True))
+
+# This works too(!). Changing 'blob' to 'raw' matches the 'download' button url.
+#graphic.add(PNG_from_web("https://github.com/ulx3s/ulx3s-pinout/raw/main/ulx3s.png", width=1372, height=742, embed=True))
 
 # Create a single pin label
 graphic.add(


### PR DESCRIPTION
The Image component in _pinout_ is a bit short sighted and caters purely for local file system paths only.
This pull request includes a custom component that can link or embed a PNG image from a web URL.

I plan to merge this into pinout for later release so a valuable exercise for me to undertake :)